### PR TITLE
feat: add Cloudflare Zero Trust (Access Service Token) support

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -14,6 +14,12 @@ export class RemnawaveClient {
         if (config.apiKey) {
             this.headers['X-Api-Key'] = config.apiKey;
         }
+        if (config.cfAccessClientId) {
+            this.headers['CF-Access-Client-Id'] = config.cfAccessClientId;
+        }
+        if (config.cfAccessClientSecret) {
+            this.headers['CF-Access-Client-Secret'] = config.cfAccessClientSecret;
+        }
     }
 
     private async request<T = unknown>(

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,8 @@ export interface Config {
     baseUrl: string;
     apiToken: string;
     apiKey?: string;
+    cfAccessClientId?: string;
+    cfAccessClientSecret?: string;
     readonly: boolean;
 }
 
@@ -9,6 +11,8 @@ export function loadConfig(): Config {
     const baseUrl = process.env.REMNAWAVE_BASE_URL;
     const apiToken = process.env.REMNAWAVE_API_TOKEN;
     const apiKey = process.env.REMNAWAVE_API_KEY;
+    const cfAccessClientId = process.env.CF_ACCESS_CLIENT_ID;
+    const cfAccessClientSecret = process.env.CF_ACCESS_CLIENT_SECRET;
     const readonly = process.env.REMNAWAVE_READONLY === 'true';
 
     if (!baseUrl) {
@@ -22,6 +26,8 @@ export function loadConfig(): Config {
         baseUrl: baseUrl.replace(/\/+$/, ''),
         apiToken,
         apiKey,
+        cfAccessClientId,
+        cfAccessClientSecret,
         readonly,
     };
 }


### PR DESCRIPTION
## What & Why

Many users run Remnawave behind a **Cloudflare Tunnel + Cloudflare Access** policy for Zero Trust protection. In this setup every HTTP request must carry two headers:

```
CF-Access-Client-Id: <Service Token ID>
CF-Access-Client-Secret: <Service Token Secret>
```

Without these headers Cloudflare returns a `403 Forbidden` before the request ever reaches Remnawave, making the MCP server unusable in such environments.

## Changes

### `src/config.ts`
- Added two optional fields to the `Config` interface:
  - `cfAccessClientId?: string`
  - `cfAccessClientSecret?: string`
- Added corresponding env variable reads in `loadConfig()`:
  - `CF_ACCESS_CLIENT_ID`
  - `CF_ACCESS_CLIENT_SECRET`

### `src/client/index.ts`
- In `RemnawaveClient` constructor: when `cfAccessClientId` / `cfAccessClientSecret` are present, they are appended to the outgoing `headers` map as `CF-Access-Client-Id` / `CF-Access-Client-Secret`.

Both fields are **optional** — existing users who don't use Cloudflare Access are completely unaffected (zero behaviour change for them).

## Configuration

```env
# Required as always
REMNAWAVE_BASE_URL=https://your-panel.example.com
REMNAWAVE_API_TOKEN=your-remnawave-api-token

# Optional — only needed when panel is behind Cloudflare Access
CF_ACCESS_CLIENT_ID=xxxxxxxxxxxxxxxx.access
CF_ACCESS_CLIENT_SECRET=yyyyyyyyyyyyyyyy

REMNAWAVE_READONLY=true
```

Service Tokens are created in: **Cloudflare Zero Trust → Access → Service Auth → Service Tokens**.

## Tested

- Cloudflare Tunnel → Caddy → Remnawave panel
- Both `REMNAWAVE_READONLY=true` (69 tools) and full mode (153 tools)
- Confirmed: without the headers → `403`; with headers → full API access

## Docs reference

- [Cloudflare Access Service Tokens](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/)
