### PR TITLE
Fix API mismatches, add 15 missing tools, support panel 2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 MCP server ([Model Context Protocol](https://modelcontextprotocol.io)) providing LLM clients (Claude Desktop, Cursor, Windsurf, etc.) with tools to manage a [Remnawave](https://github.com/remnawave/) VPN panel.
 
-**Version:** 1.2.0 | **Remnawave API:** 2.7.4
+**Version:** 1.3.0 | **Remnawave API:** 2.7.4
 
 ### Features
 
-- **153 tools** — full management of users, nodes, hosts, subscriptions, squads, HWID, config profiles, inbounds, API tokens, billing, snippets, external squads, settings, subscription page configs, node plugins, IP control, and metadata
+- **166 tools** — full management of users, nodes, hosts, subscriptions, squads, HWID, config profiles, inbounds, API tokens, billing, snippets, external squads, settings, subscription settings, subscription templates, subscription page configs, node plugins, IP control, and metadata
 - **3 resources** — real-time panel stats, node status, health checks
 - **5 prompts** — guided workflows for common tasks
-- **Readonly mode** — restrict to 69 read-only tools for safe monitoring
+- **Readonly mode** — restrict to 75 read-only tools for safe monitoring
 - **Caddy support** — `X-Api-Key` header for panels behind Caddy with custom path
 - **Type-safe** — built on [@remnawave/backend-contract](https://www.npmjs.com/package/@remnawave/backend-contract) for API route validation
 - **stdio transport** — works with Claude Desktop, Cursor, Windsurf, and any MCP-compatible client
@@ -69,17 +69,17 @@ Set `REMNAWAVE_READONLY=true` to disable all write operations (create, update, d
 
 Useful for monitoring dashboards or shared environments where you want to prevent accidental changes.
 
-In readonly mode, the available tools are reduced from 153 to 69:
+In readonly mode, the available tools are reduced from 166 to 75:
 
 | Category | Available tools |
 |----------|----------------|
-| Users (10) | `users_list`, `users_get`, `users_get_by_username`, `users_get_by_short_uuid`, `users_get_by_telegram_id`, `users_get_by_email`, `users_get_by_tag`, `users_get_by_subscription_uuid`, `users_tags_list`, `users_resolve` |
+| Users (12) | `users_list`, `users_get`, `users_get_by_username`, `users_get_by_short_uuid`, `users_get_by_telegram_id`, `users_get_by_email`, `users_get_by_tag`, `users_get_by_subscription_uuid`, `users_get_by_id`, `users_accessible_nodes`, `users_tags_list`, `users_resolve` |
 | Nodes (3) | `nodes_list`, `nodes_get`, `nodes_tags_list` |
 | Hosts (3) | `hosts_list`, `hosts_get`, `hosts_tags_list` |
 | System (10) | all tools (read-only by nature) |
 | Subscriptions (10) | all tools (read-only by nature) |
 | Config Profiles & Inbounds (5) | `config_profiles_list`, `config_profiles_get`, `inbounds_list`, `config_profiles_get_inbounds`, `config_profiles_get_computed_config` |
-| Internal Squads (2) | `squads_list`, `squads_accessible_nodes` |
+| Internal Squads (3) | `squads_list`, `squads_get`, `squads_accessible_nodes` |
 | HWID (4) | `hwid_devices_list`, `hwid_devices_list_all`, `hwid_stats`, `hwid_top_users` |
 | API Tokens (1) | `api_tokens_list` |
 | Keygen (1) | `keygen_get` |
@@ -87,6 +87,8 @@ In readonly mode, the available tools are reduced from 153 to 69:
 | Snippets (1) | `snippets_list` |
 | External Squads (2) | `external_squads_list`, `external_squads_get` |
 | Settings (1) | `settings_get` |
+| Subscription Settings (1) | `subscription_settings_get` |
+| Subscription Templates (2) | `subscription_templates_list`, `subscription_templates_get` |
 | Sub Page Configs (2) | `sub_page_configs_list`, `sub_page_configs_get` |
 | Node Plugins (4) | `node_plugins_list`, `node_plugins_get`, `node_plugins_torrent_reports`, `node_plugins_torrent_stats` |
 | IP Control (4) | `ip_control_fetch_ips`, `ip_control_get_fetch_ips_result`, `ip_control_fetch_users_ips`, `ip_control_get_fetch_users_ips_result` |
@@ -145,7 +147,7 @@ Environment variables are passed via `.env` file or `docker-compose.yml`.
 
 ### Available Tools
 
-#### Users (27 tools)
+#### Users (29 tools)
 
 | Tool | Description | Mode |
 |------|-------------|------|
@@ -157,6 +159,8 @@ Environment variables are passed via `.env` file or `docker-compose.yml`.
 | `users_get_by_email` | Get user by email | read |
 | `users_get_by_tag` | Get user by tag | read |
 | `users_get_by_subscription_uuid` | Get user by subscription UUID | read |
+| `users_get_by_id` | Get user by numeric ID | read |
+| `users_accessible_nodes` | Get nodes accessible to a user | read |
 | `users_tags_list` | List all user tags | read |
 | `users_resolve` | Resolve users by multiple criteria | read |
 | `users_create` | Create a new user | write |
@@ -197,7 +201,7 @@ Environment variables are passed via `.env` file or `docker-compose.yml`.
 | `nodes_bulk_actions` | Bulk node actions | write |
 | `nodes_bulk_update` | Bulk update nodes | write |
 
-#### Hosts (11 tools)
+#### Hosts (12 tools)
 
 | Tool | Description | Mode |
 |------|-------------|------|
@@ -212,6 +216,7 @@ Environment variables are passed via `.env` file or `docker-compose.yml`.
 | `hosts_bulk_delete` | Bulk delete hosts | write |
 | `hosts_bulk_set_inbound` | Bulk set host inbound | write |
 | `hosts_bulk_set_port` | Bulk set host port | write |
+| `hosts_reorder` | Reorder hosts | write |
 
 #### System (10 tools)
 
@@ -257,17 +262,19 @@ Environment variables are passed via `.env` file or `docker-compose.yml`.
 | `config_profiles_delete` | Delete config profile | write |
 | `config_profiles_reorder` | Reorder config profiles | write |
 
-#### Internal Squads (7 tools)
+#### Internal Squads (9 tools)
 
 | Tool | Description | Mode |
 |------|-------------|------|
 | `squads_list` | List all squads | read |
+| `squads_get` | Get squad by UUID | read |
 | `squads_accessible_nodes` | Get squad accessible nodes | read |
 | `squads_create` | Create a squad | write |
 | `squads_update` | Update a squad | write |
 | `squads_delete` | Delete a squad | write |
 | `squads_add_users` | Add users to a squad | write |
 | `squads_remove_users` | Remove users from a squad | write |
+| `squads_reorder` | Reorder squads | write |
 
 #### HWID Devices (7 tools)
 
@@ -340,6 +347,24 @@ Environment variables are passed via `.env` file or `docker-compose.yml`.
 |------|-------------|------|
 | `settings_get` | Get panel settings | read |
 | `settings_update` | Update panel settings | write |
+
+#### Subscription Settings (2 tools)
+
+| Tool | Description | Mode |
+|------|-------------|------|
+| `subscription_settings_get` | Get subscription settings | read |
+| `subscription_settings_update` | Update subscription settings (profile title, support link, update interval, HAPP, HWID, response rules, etc.) | write |
+
+#### Subscription Templates (6 tools)
+
+| Tool | Description | Mode |
+|------|-------------|------|
+| `subscription_templates_list` | List all subscription templates | read |
+| `subscription_templates_get` | Get subscription template by UUID | read |
+| `subscription_templates_create` | Create a subscription template | write |
+| `subscription_templates_update` | Update a subscription template | write |
+| `subscription_templates_delete` | Delete a subscription template | write |
+| `subscription_templates_reorder` | Reorder subscription templates | write |
 
 #### Subscription Page Configs (7 tools)
 
@@ -433,18 +458,20 @@ src/
 ├── tools/
 │   ├── helpers.ts                 # Result formatting helpers
 │   ├── index.ts                   # Tool registration
-│   ├── users.ts                   # User management (27 tools)
+│   ├── users.ts                   # User management (29 tools)
 │   ├── nodes.ts                   # Node management (15 tools)
-│   ├── hosts.ts                   # Host management (11 tools)
+│   ├── hosts.ts                   # Host management (12 tools)
 │   ├── system.ts                  # System & auth (10 tools)
 │   ├── subscriptions.ts           # Subscriptions (10 tools)
 │   ├── inbounds.ts                # Config profiles & inbounds (9 tools)
-│   ├── squads.ts                  # Internal squads (7 tools)
+│   ├── squads.ts                  # Internal squads (9 tools)
 │   ├── hwid.ts                    # HWID devices (7 tools)
 │   ├── infra-billing.ts           # Infrastructure billing (12 tools)
 │   ├── node-plugins.ts            # Node plugins (11 tools)
 │   ├── external-squads.ts         # External squads (8 tools)
 │   ├── subscription-page-configs.ts # Subscription page configs (7 tools)
+│   ├── subscription-settings.ts  # Subscription settings (2 tools)
+│   ├── subscription-templates.ts # Subscription templates (6 tools)
 │   ├── ip-control.ts              # IP control (5 tools)
 │   ├── snippets.ts                # Snippets (4 tools)
 │   ├── metadata.ts                # Node & user metadata (4 tools)
@@ -469,14 +496,14 @@ MIT
 
 MCP-сервер ([Model Context Protocol](https://modelcontextprotocol.io)), предоставляющий LLM-клиентам (Claude Desktop, Cursor, Windsurf и др.) инструменты для управления VPN-панелью [Remnawave](https://github.com/remnawave/).
 
-**Версия:** 1.2.0 | **Remnawave API:** 2.7.4
+**Версия:** 1.3.0 | **Remnawave API:** 2.7.4
 
 ### Возможности
 
-- **153 инструмента** — полное управление пользователями, нодами, хостами, подписками, группами, HWID, конфиг-профилями, inbounds, API-токенами, биллингом, сниппетами, внешними группами, настройками, страницами подписок, плагинами нод, IP-контролем и метаданными
+- **166 инструментов** — полное управление пользователями, нодами, хостами, подписками, группами, HWID, конфиг-профилями, inbounds, API-токенами, биллингом, сниппетами, внешними группами, настройками, настройками подписок, шаблонами подписок, страницами подписок, плагинами нод, IP-контролем и метаданными
 - **3 ресурса** — статистика панели, статус нод, проверка здоровья в реальном времени
 - **5 промптов** — пошаговые сценарии для типичных задач
-- **Readonly-режим** — ограничение до 69 инструментов только для чтения
+- **Readonly-режим** — ограничение до 75 инструментов только для чтения
 - **Поддержка Caddy** — заголовок `X-Api-Key` для панелей за Caddy с кастомным путём
 - **Type-safe** — построен на [@remnawave/backend-contract](https://www.npmjs.com/package/@remnawave/backend-contract) для валидации API-маршрутов
 - **stdio транспорт** — работает с Claude Desktop, Cursor, Windsurf и любым MCP-совместимым клиентом
@@ -528,17 +555,17 @@ REMNAWAVE_API_KEY=ваш-caddy-api-ключ
 
 Полезно для мониторинговых дашбордов или общих окружений, где нужно исключить случайные изменения.
 
-В readonly-режиме количество доступных инструментов сокращается с 153 до 69:
+В readonly-режиме количество доступных инструментов сокращается с 166 до 75:
 
 | Категория | Доступные инструменты |
 |-----------|----------------------|
-| Пользователи (10) | `users_list`, `users_get`, `users_get_by_username`, `users_get_by_short_uuid`, `users_get_by_telegram_id`, `users_get_by_email`, `users_get_by_tag`, `users_get_by_subscription_uuid`, `users_tags_list`, `users_resolve` |
+| Пользователи (12) | `users_list`, `users_get`, `users_get_by_username`, `users_get_by_short_uuid`, `users_get_by_telegram_id`, `users_get_by_email`, `users_get_by_tag`, `users_get_by_subscription_uuid`, `users_get_by_id`, `users_accessible_nodes`, `users_tags_list`, `users_resolve` |
 | Ноды (3) | `nodes_list`, `nodes_get`, `nodes_tags_list` |
 | Хосты (3) | `hosts_list`, `hosts_get`, `hosts_tags_list` |
 | Система (10) | все инструменты (только чтение по природе) |
 | Подписки (10) | все инструменты (только чтение по природе) |
 | Конфиг-профили и Inbounds (5) | `config_profiles_list`, `config_profiles_get`, `inbounds_list`, `config_profiles_get_inbounds`, `config_profiles_get_computed_config` |
-| Внутренние группы (2) | `squads_list`, `squads_accessible_nodes` |
+| Внутренние группы (3) | `squads_list`, `squads_get`, `squads_accessible_nodes` |
 | HWID (4) | `hwid_devices_list`, `hwid_devices_list_all`, `hwid_stats`, `hwid_top_users` |
 | API-токены (1) | `api_tokens_list` |
 | Keygen (1) | `keygen_get` |
@@ -546,6 +573,8 @@ REMNAWAVE_API_KEY=ваш-caddy-api-ключ
 | Сниппеты (1) | `snippets_list` |
 | Внешние группы (2) | `external_squads_list`, `external_squads_get` |
 | Настройки (1) | `settings_get` |
+| Настройки подписок (1) | `subscription_settings_get` |
+| Шаблоны подписок (2) | `subscription_templates_list`, `subscription_templates_get` |
 | Страницы подписок (2) | `sub_page_configs_list`, `sub_page_configs_get` |
 | Плагины нод (4) | `node_plugins_list`, `node_plugins_get`, `node_plugins_torrent_reports`, `node_plugins_torrent_stats` |
 | IP-контроль (4) | `ip_control_fetch_ips`, `ip_control_get_fetch_ips_result`, `ip_control_fetch_users_ips`, `ip_control_get_fetch_users_ips_result` |
@@ -604,7 +633,7 @@ docker compose up -d
 
 ### Доступные инструменты
 
-#### Пользователи (27 инструментов)
+#### Пользователи (29 инструментов)
 
 | Инструмент | Описание | Режим |
 |------------|----------|-------|
@@ -616,6 +645,8 @@ docker compose up -d
 | `users_get_by_email` | Получить пользователя по email | read |
 | `users_get_by_tag` | Получить пользователя по тегу | read |
 | `users_get_by_subscription_uuid` | Получить пользователя по UUID подписки | read |
+| `users_get_by_id` | Получить пользователя по числовому ID | read |
+| `users_accessible_nodes` | Получить ноды, доступные пользователю | read |
 | `users_tags_list` | Список тегов пользователей | read |
 | `users_resolve` | Поиск пользователей по нескольким критериям | read |
 | `users_create` | Создать нового пользователя | write |
@@ -656,7 +687,7 @@ docker compose up -d
 | `nodes_bulk_actions` | Массовые действия с нодами | write |
 | `nodes_bulk_update` | Массовое обновление нод | write |
 
-#### Хосты (11 инструментов)
+#### Хосты (12 инструментов)
 
 | Инструмент | Описание | Режим |
 |------------|----------|-------|
@@ -671,6 +702,7 @@ docker compose up -d
 | `hosts_bulk_delete` | Массовое удаление хостов | write |
 | `hosts_bulk_set_inbound` | Массовая установка inbound | write |
 | `hosts_bulk_set_port` | Массовая установка порта | write |
+| `hosts_reorder` | Переупорядочить хосты | write |
 
 #### Система (10 инструментов)
 
@@ -716,17 +748,19 @@ docker compose up -d
 | `config_profiles_delete` | Удалить конфиг-профиль | write |
 | `config_profiles_reorder` | Переупорядочить конфиг-профили | write |
 
-#### Внутренние группы (7 инструментов)
+#### Внутренние группы (9 инструментов)
 
 | Инструмент | Описание | Режим |
 |------------|----------|-------|
 | `squads_list` | Список групп | read |
+| `squads_get` | Получить группу по UUID | read |
 | `squads_accessible_nodes` | Доступные ноды группы | read |
 | `squads_create` | Создать группу | write |
 | `squads_update` | Обновить группу | write |
 | `squads_delete` | Удалить группу | write |
 | `squads_add_users` | Добавить пользователей в группу | write |
 | `squads_remove_users` | Убрать пользователей из группы | write |
+| `squads_reorder` | Переупорядочить группы | write |
 
 #### HWID-устройства (7 инструментов)
 
@@ -799,6 +833,24 @@ docker compose up -d
 |------------|----------|-------|
 | `settings_get` | Получить настройки панели | read |
 | `settings_update` | Обновить настройки панели | write |
+
+#### Настройки подписок (2 инструмента)
+
+| Инструмент | Описание | Режим |
+|------------|----------|-------|
+| `subscription_settings_get` | Получить настройки подписок | read |
+| `subscription_settings_update` | Обновить настройки подписок (заголовок профиля, ссылка поддержки, интервал обновления, HAPP, HWID, правила ответов и др.) | write |
+
+#### Шаблоны подписок (6 инструментов)
+
+| Инструмент | Описание | Режим |
+|------------|----------|-------|
+| `subscription_templates_list` | Список шаблонов подписок | read |
+| `subscription_templates_get` | Получить шаблон по UUID | read |
+| `subscription_templates_create` | Создать шаблон подписки | write |
+| `subscription_templates_update` | Обновить шаблон подписки | write |
+| `subscription_templates_delete` | Удалить шаблон подписки | write |
+| `subscription_templates_reorder` | Переупорядочить шаблоны | write |
 
 #### Страницы подписок (7 инструментов)
 
@@ -892,18 +944,20 @@ src/
 ├── tools/
 │   ├── helpers.ts                 # Хелперы форматирования
 │   ├── index.ts                   # Регистрация инструментов
-│   ├── users.ts                   # Управление пользователями (27)
+│   ├── users.ts                   # Управление пользователями (29)
 │   ├── nodes.ts                   # Управление нодами (15)
-│   ├── hosts.ts                   # Управление хостами (11)
+│   ├── hosts.ts                   # Управление хостами (12)
 │   ├── system.ts                  # Система и авторизация (10)
 │   ├── subscriptions.ts           # Подписки (10)
 │   ├── inbounds.ts                # Конфиг-профили и inbounds (9)
-│   ├── squads.ts                  # Внутренние группы (7)
+│   ├── squads.ts                  # Внутренние группы (9)
 │   ├── hwid.ts                    # HWID-устройства (7)
 │   ├── infra-billing.ts           # Биллинг инфраструктуры (12)
 │   ├── node-plugins.ts            # Плагины нод (11)
 │   ├── external-squads.ts         # Внешние группы (8)
 │   ├── subscription-page-configs.ts # Страницы подписок (7)
+│   ├── subscription-settings.ts  # Настройки подписок (2)
+│   ├── subscription-templates.ts # Шаблоны подписок (6)
 │   ├── ip-control.ts              # IP-контроль (5)
 │   ├── snippets.ts                # Сниппеты (4)
 │   ├── metadata.ts                # Метаданные нод и пользователей (4)

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 MCP server ([Model Context Protocol](https://modelcontextprotocol.io)) providing LLM clients (Claude Desktop, Cursor, Windsurf, etc.) with tools to manage a [Remnawave](https://github.com/remnawave/) VPN panel.
 
-**Version:** 1.3.0 | **Remnawave API:** 2.7.4
+**Version:** 1.4.0 | **Remnawave API:** 2.8.0
 
 ### Features
 
 - **166 tools** — full management of users, nodes, hosts, subscriptions, squads, HWID, config profiles, inbounds, API tokens, billing, snippets, external squads, settings, subscription settings, subscription templates, subscription page configs, node plugins, IP control, and metadata
 - **3 resources** — real-time panel stats, node status, health checks
 - **5 prompts** — guided workflows for common tasks
-- **Readonly mode** — restrict to 75 read-only tools for safe monitoring
+- **Readonly mode** — restrict to 76 read-only tools for safe monitoring
 - **Caddy support** — `X-Api-Key` header for panels behind Caddy with custom path
 - **Type-safe** — built on [@remnawave/backend-contract](https://www.npmjs.com/package/@remnawave/backend-contract) for API route validation
 - **stdio transport** — works with Claude Desktop, Cursor, Windsurf, and any MCP-compatible client
@@ -69,14 +69,14 @@ Set `REMNAWAVE_READONLY=true` to disable all write operations (create, update, d
 
 Useful for monitoring dashboards or shared environments where you want to prevent accidental changes.
 
-In readonly mode, the available tools are reduced from 166 to 75:
+In readonly mode, the available tools are reduced from 166 to 76:
 
 | Category | Available tools |
 |----------|----------------|
 | Users (12) | `users_list`, `users_get`, `users_get_by_username`, `users_get_by_short_uuid`, `users_get_by_telegram_id`, `users_get_by_email`, `users_get_by_tag`, `users_get_by_subscription_uuid`, `users_get_by_id`, `users_accessible_nodes`, `users_tags_list`, `users_resolve` |
 | Nodes (3) | `nodes_list`, `nodes_get`, `nodes_tags_list` |
 | Hosts (3) | `hosts_list`, `hosts_get`, `hosts_tags_list` |
-| System (10) | all tools (read-only by nature) |
+| System (11) | all tools (read-only by nature), incl. `bandwidth_stats_users_by_nodes` |
 | Subscriptions (10) | all tools (read-only by nature) |
 | Config Profiles & Inbounds (5) | `config_profiles_list`, `config_profiles_get`, `inbounds_list`, `config_profiles_get_inbounds`, `config_profiles_get_computed_config` |
 | Internal Squads (3) | `squads_list`, `squads_get`, `squads_accessible_nodes` |
@@ -201,29 +201,29 @@ Environment variables are passed via `.env` file or `docker-compose.yml`.
 | `nodes_bulk_actions` | Bulk node actions | write |
 | `nodes_bulk_update` | Bulk update nodes | write |
 
-#### Hosts (12 tools)
+#### Hosts (11 tools)
 
 | Tool | Description | Mode |
 |------|-------------|------|
 | `hosts_list` | List all hosts | read |
 | `hosts_get` | Get host by UUID | read |
 | `hosts_tags_list` | List all host tags | read |
-| `hosts_create` | Create a new host | write |
-| `hosts_update` | Update host settings | write |
+| `hosts_create` | Create a new host (tags, cert pinning, mihomoIpVersion) | write |
+| `hosts_update` | Update host settings (tags, cert pinning, mihomoIpVersion) | write |
 | `hosts_delete` | Delete a host | write |
 | `hosts_bulk_enable` | Bulk enable hosts | write |
 | `hosts_bulk_disable` | Bulk disable hosts | write |
 | `hosts_bulk_delete` | Bulk delete hosts | write |
-| `hosts_bulk_set_inbound` | Bulk set host inbound | write |
-| `hosts_bulk_set_port` | Bulk set host port | write |
+| `hosts_bulk_update` | Bulk update host fields (port, inbound, tags, etc.) | write |
 | `hosts_reorder` | Reorder hosts | write |
 
-#### System (10 tools)
+#### System (11 tools)
 
 | Tool | Description | Mode |
 |------|-------------|------|
 | `system_stats` | Panel statistics (users, nodes, traffic, CPU, memory) | read |
 | `system_bandwidth_stats` | Bandwidth statistics | read |
+| `bandwidth_stats_users_by_nodes` | Top per-user bandwidth usage across nodes for a date range | read |
 | `system_nodes_metrics` | Node metrics | read |
 | `system_nodes_statistics` | Node statistics | read |
 | `system_health` | Panel health check | read |
@@ -460,8 +460,8 @@ src/
 │   ├── index.ts                   # Tool registration
 │   ├── users.ts                   # User management (29 tools)
 │   ├── nodes.ts                   # Node management (15 tools)
-│   ├── hosts.ts                   # Host management (12 tools)
-│   ├── system.ts                  # System & auth (10 tools)
+│   ├── hosts.ts                   # Host management (11 tools)
+│   ├── system.ts                  # System & auth (11 tools)
 │   ├── subscriptions.ts           # Subscriptions (10 tools)
 │   ├── inbounds.ts                # Config profiles & inbounds (9 tools)
 │   ├── squads.ts                  # Internal squads (9 tools)
@@ -496,14 +496,14 @@ MIT
 
 MCP-сервер ([Model Context Protocol](https://modelcontextprotocol.io)), предоставляющий LLM-клиентам (Claude Desktop, Cursor, Windsurf и др.) инструменты для управления VPN-панелью [Remnawave](https://github.com/remnawave/).
 
-**Версия:** 1.3.0 | **Remnawave API:** 2.7.4
+**Версия:** 1.4.0 | **Remnawave API:** 2.8.0
 
 ### Возможности
 
 - **166 инструментов** — полное управление пользователями, нодами, хостами, подписками, группами, HWID, конфиг-профилями, inbounds, API-токенами, биллингом, сниппетами, внешними группами, настройками, настройками подписок, шаблонами подписок, страницами подписок, плагинами нод, IP-контролем и метаданными
 - **3 ресурса** — статистика панели, статус нод, проверка здоровья в реальном времени
 - **5 промптов** — пошаговые сценарии для типичных задач
-- **Readonly-режим** — ограничение до 75 инструментов только для чтения
+- **Readonly-режим** — ограничение до 76 инструментов только для чтения
 - **Поддержка Caddy** — заголовок `X-Api-Key` для панелей за Caddy с кастомным путём
 - **Type-safe** — построен на [@remnawave/backend-contract](https://www.npmjs.com/package/@remnawave/backend-contract) для валидации API-маршрутов
 - **stdio транспорт** — работает с Claude Desktop, Cursor, Windsurf и любым MCP-совместимым клиентом
@@ -555,14 +555,14 @@ REMNAWAVE_API_KEY=ваш-caddy-api-ключ
 
 Полезно для мониторинговых дашбордов или общих окружений, где нужно исключить случайные изменения.
 
-В readonly-режиме количество доступных инструментов сокращается с 166 до 75:
+В readonly-режиме количество доступных инструментов сокращается с 166 до 76:
 
 | Категория | Доступные инструменты |
 |-----------|----------------------|
 | Пользователи (12) | `users_list`, `users_get`, `users_get_by_username`, `users_get_by_short_uuid`, `users_get_by_telegram_id`, `users_get_by_email`, `users_get_by_tag`, `users_get_by_subscription_uuid`, `users_get_by_id`, `users_accessible_nodes`, `users_tags_list`, `users_resolve` |
 | Ноды (3) | `nodes_list`, `nodes_get`, `nodes_tags_list` |
 | Хосты (3) | `hosts_list`, `hosts_get`, `hosts_tags_list` |
-| Система (10) | все инструменты (только чтение по природе) |
+| Система (11) | все инструменты (только чтение по природе), вкл. `bandwidth_stats_users_by_nodes` |
 | Подписки (10) | все инструменты (только чтение по природе) |
 | Конфиг-профили и Inbounds (5) | `config_profiles_list`, `config_profiles_get`, `inbounds_list`, `config_profiles_get_inbounds`, `config_profiles_get_computed_config` |
 | Внутренние группы (3) | `squads_list`, `squads_get`, `squads_accessible_nodes` |
@@ -687,29 +687,29 @@ docker compose up -d
 | `nodes_bulk_actions` | Массовые действия с нодами | write |
 | `nodes_bulk_update` | Массовое обновление нод | write |
 
-#### Хосты (12 инструментов)
+#### Хосты (11 инструментов)
 
 | Инструмент | Описание | Режим |
 |------------|----------|-------|
 | `hosts_list` | Список всех хостов | read |
 | `hosts_get` | Получить хост по UUID | read |
 | `hosts_tags_list` | Список тегов хостов | read |
-| `hosts_create` | Создать новый хост | write |
-| `hosts_update` | Обновить настройки хоста | write |
+| `hosts_create` | Создать новый хост (tags, cert pinning, mihomoIpVersion) | write |
+| `hosts_update` | Обновить настройки хоста (tags, cert pinning, mihomoIpVersion) | write |
 | `hosts_delete` | Удалить хост | write |
 | `hosts_bulk_enable` | Массовое включение хостов | write |
 | `hosts_bulk_disable` | Массовое отключение хостов | write |
 | `hosts_bulk_delete` | Массовое удаление хостов | write |
-| `hosts_bulk_set_inbound` | Массовая установка inbound | write |
-| `hosts_bulk_set_port` | Массовая установка порта | write |
+| `hosts_bulk_update` | Массовое обновление полей хостов (порт, inbound, теги и т.д.) | write |
 | `hosts_reorder` | Переупорядочить хосты | write |
 
-#### Система (10 инструментов)
+#### Система (11 инструментов)
 
 | Инструмент | Описание | Режим |
 |------------|----------|-------|
 | `system_stats` | Статистика панели (пользователи, ноды, трафик, CPU, память) | read |
 | `system_bandwidth_stats` | Статистика пропускной способности | read |
+| `bandwidth_stats_users_by_nodes` | Топ потребления трафика по пользователям на нодах за период | read |
 | `system_nodes_metrics` | Метрики нод | read |
 | `system_nodes_statistics` | Статистика нод | read |
 | `system_health` | Проверка здоровья панели | read |
@@ -946,8 +946,8 @@ src/
 │   ├── index.ts                   # Регистрация инструментов
 │   ├── users.ts                   # Управление пользователями (29)
 │   ├── nodes.ts                   # Управление нодами (15)
-│   ├── hosts.ts                   # Управление хостами (12)
-│   ├── system.ts                  # Система и авторизация (10)
+│   ├── hosts.ts                   # Управление хостами (11)
+│   ├── system.ts                  # Система и авторизация (11)
 │   ├── subscriptions.ts           # Подписки (10)
 │   ├── inbounds.ts                # Конфиг-профили и inbounds (9)
 │   ├── squads.ts                  # Внутренние группы (9)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "remnawave-mcp",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remnawave-mcp",
-      "version": "1.0.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@remnawave/backend-contract": "^2.6.27",
+        "@remnawave/backend-contract": "2.7.2",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remnawave-mcp",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "description": "MCP server for Remnawave proxy management panel",
   "type": "module",
   "bin": {
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@remnawave/backend-contract": "^2.6.27",
+    "@remnawave/backend-contract": "2.7.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -230,8 +230,8 @@ export class RemnawaveClient {
         return this.post(REST_API.NODES.ACTIONS.RESET_TRAFFIC(uuid));
     }
 
-    async reorderNodes(uuids: string[]) {
-        return this.post(REST_API.NODES.ACTIONS.REORDER, uuids);
+    async reorderNodes(nodes: { uuid: string; viewPosition: number }[]) {
+        return this.post(REST_API.NODES.ACTIONS.REORDER, { nodes });
     }
 
     async bulkNodeProfileModification(params: Record<string, unknown>) {
@@ -579,15 +579,28 @@ export class RemnawaveClient {
     }
 
     async createSnippet(params: Record<string, unknown>) {
-        return this.post(REST_API.SNIPPETS.CREATE, params);
+        const body: Record<string, unknown> = { name: params.name };
+        if (params.snippet !== undefined) {
+            body.snippet = typeof params.snippet === 'string'
+                ? JSON.parse(params.snippet as string)
+                : params.snippet;
+        }
+        return this.post(REST_API.SNIPPETS.CREATE, body);
     }
 
     async updateSnippet(params: Record<string, unknown>) {
-        return this.patch(REST_API.SNIPPETS.UPDATE, params);
+        const body: Record<string, unknown> = { name: params.name };
+        if (params.newName !== undefined) body.name = params.newName;
+        if (params.snippet !== undefined) {
+            body.snippet = typeof params.snippet === 'string'
+                ? JSON.parse(params.snippet as string)
+                : params.snippet;
+        }
+        return this.patch(REST_API.SNIPPETS.UPDATE, body);
     }
 
     async deleteSnippet(params: Record<string, unknown>) {
-        return this.post(REST_API.SNIPPETS.DELETE, params);
+        return this.request('DELETE', REST_API.SNIPPETS.DELETE as string, { name: params.name });
     }
 
     // External Squads

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -104,6 +104,10 @@ export class RemnawaveClient {
         return this.get(REST_API.USERS.GET_BY.ID(id));
     }
 
+    async getUserAccessibleNodes(uuid: string) {
+        return this.get(REST_API.USERS.ACCESSIBLE_NODES(uuid));
+    }
+
     async getUserBySubscriptionUuid(subscriptionUuid: string) {
         return this.get(REST_API.USERS.GET_BY.SUBSCRIPTION_UUID(subscriptionUuid));
     }
@@ -292,6 +296,10 @@ export class RemnawaveClient {
         return this.post(REST_API.HOSTS.BULK.SET_PORT, params);
     }
 
+    async reorderHosts(hosts: { uuid: string; viewPosition: number }[]) {
+        return this.post(REST_API.HOSTS.ACTIONS.REORDER, { hosts });
+    }
+
     // System
 
     async getStats() {
@@ -418,6 +426,10 @@ export class RemnawaveClient {
         return this.get(REST_API.INTERNAL_SQUADS.GET);
     }
 
+    async getInternalSquadByUuid(uuid: string) {
+        return this.get(REST_API.INTERNAL_SQUADS.GET_BY_UUID(uuid));
+    }
+
     async getSquadAccessibleNodes(uuid: string) {
         return this.get(REST_API.INTERNAL_SQUADS.ACCESSIBLE_NODES(uuid));
     }
@@ -432,6 +444,10 @@ export class RemnawaveClient {
 
     async deleteInternalSquad(uuid: string) {
         return this.delete(REST_API.INTERNAL_SQUADS.DELETE(uuid));
+    }
+
+    async reorderInternalSquads(params: Record<string, unknown>) {
+        return this.post(REST_API.INTERNAL_SQUADS.ACTIONS.REORDER, params);
     }
 
     async addUsersToSquad(squadUuid: string, userUuids: string[]) {
@@ -767,5 +783,41 @@ export class RemnawaveClient {
 
     async upsertUserMetadata(uuid: string, params: Record<string, unknown>) {
         return this.put(REST_API.METADATA.USER.UPSERT(uuid), params);
+    }
+
+    // Subscription Settings
+
+    async getSubscriptionSettings() {
+        return this.get(REST_API.SUBSCRIPTION_SETTINGS.GET);
+    }
+
+    async updateSubscriptionSettings(params: Record<string, unknown>) {
+        return this.patch(REST_API.SUBSCRIPTION_SETTINGS.UPDATE, params);
+    }
+
+    // Subscription Templates
+
+    async getSubscriptionTemplates() {
+        return this.get(REST_API.SUBSCRIPTION_TEMPLATE.GET_ALL);
+    }
+
+    async getSubscriptionTemplateByUuid(uuid: string) {
+        return this.get(REST_API.SUBSCRIPTION_TEMPLATE.GET(uuid));
+    }
+
+    async createSubscriptionTemplate(params: Record<string, unknown>) {
+        return this.post(REST_API.SUBSCRIPTION_TEMPLATE.CREATE, params);
+    }
+
+    async updateSubscriptionTemplate(params: Record<string, unknown>) {
+        return this.patch(REST_API.SUBSCRIPTION_TEMPLATE.UPDATE, params);
+    }
+
+    async deleteSubscriptionTemplate(uuid: string) {
+        return this.delete(REST_API.SUBSCRIPTION_TEMPLATE.DELETE(uuid));
+    }
+
+    async reorderSubscriptionTemplates(params: Record<string, unknown>) {
+        return this.post(REST_API.SUBSCRIPTION_TEMPLATE.ACTIONS.REORDER, params);
     }
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -222,12 +222,12 @@ export class RemnawaveClient {
         return this.post(REST_API.NODES.ACTIONS.DISABLE(uuid));
     }
 
-    async restartNode(uuid: string) {
-        return this.post(REST_API.NODES.ACTIONS.RESTART(uuid));
+    async restartNode(uuid: string, forceRestart = false) {
+        return this.post(REST_API.NODES.ACTIONS.RESTART(uuid), { forceRestart });
     }
 
-    async restartAllNodes() {
-        return this.post(REST_API.NODES.ACTIONS.RESTART_ALL);
+    async restartAllNodes(forceRestart = false) {
+        return this.post(REST_API.NODES.ACTIONS.RESTART_ALL, { forceRestart });
     }
 
     async resetNodeTraffic(uuid: string) {
@@ -246,7 +246,7 @@ export class RemnawaveClient {
         return this.post(REST_API.NODES.BULK_ACTIONS.ACTIONS, params);
     }
 
-    async bulkUpdateNodes(params: Record<string, unknown>) {
+    async bulkUpdateNodes(params: { uuids: string[]; fields: Record<string, unknown> }) {
         return this.post(REST_API.NODES.BULK_ACTIONS.UPDATE, params);
     }
 
@@ -288,12 +288,10 @@ export class RemnawaveClient {
         return this.post(REST_API.HOSTS.BULK.DELETE_HOSTS, params);
     }
 
-    async bulkSetHostInbound(params: Record<string, unknown>) {
-        return this.post(REST_API.HOSTS.BULK.SET_INBOUND, params);
-    }
-
-    async bulkSetHostPort(params: Record<string, unknown>) {
-        return this.post(REST_API.HOSTS.BULK.SET_PORT, params);
+    // Panel 2.8.0 replaced /bulk/set-inbound and /bulk/set-port with /bulk/update.
+    // The pinned contract 2.7.2 predates this route, so it is declared as a literal.
+    async bulkUpdateHosts(params: Record<string, unknown>) {
+        return this.patch('/api/hosts/bulk/update', params);
     }
 
     async reorderHosts(hosts: { uuid: string; viewPosition: number }[]) {
@@ -510,6 +508,24 @@ export class RemnawaveClient {
 
     async getUserBandwidthByUuid(uuid: string) {
         return this.get(REST_API.BANDWIDTH_STATS.USERS.GET_BY_UUID(uuid));
+    }
+
+    // Panel 2.8.0 added POST /api/bandwidth-stats/nodes/users (top users usage across nodes).
+    // Not present in pinned contract 2.7.2, so declared as a literal route.
+    async getUsersUsageByNodes(
+        nodesUuids: string[],
+        start: string,
+        end: string,
+        topUsersLimit?: number,
+    ) {
+        const query = new URLSearchParams({ start, end });
+        if (topUsersLimit !== undefined) {
+            query.set('topUsersLimit', String(topUsersLimit));
+        }
+        return this.post(
+            `/api/bandwidth-stats/nodes/users?${query.toString()}`,
+            { nodesUuids },
+        );
     }
 
     // Auth

--- a/src/tools/hosts.ts
+++ b/src/tools/hosts.ts
@@ -272,4 +272,22 @@ export function registerHostTools(server: McpServer, client: RemnawaveClient, re
             try { return toolResult(await client.bulkSetHostPort(params)); } catch (e) { return toolError(e); }
         },
     );
+
+    server.tool(
+        'hosts_reorder',
+        'Reorder hosts by providing each host UUID with its new position',
+        {
+            hosts: z
+                .array(
+                    z.object({
+                        uuid: z.string().describe('Host UUID'),
+                        viewPosition: z.number().int().describe('New position (0-based)'),
+                    }),
+                )
+                .describe('Array of hosts with their new positions'),
+        },
+        async ({ hosts }) => {
+            try { return toolResult(await client.reorderHosts(hosts)); } catch (e) { return toolError(e); }
+        },
+    );
 }

--- a/src/tools/hosts.ts
+++ b/src/tools/hosts.ts
@@ -4,6 +4,10 @@ import { RemnawaveClient } from '../client/index.js';
 import { toolResult, toolError } from './helpers.js';
 
 const SUBSCRIPTION_TYPES = ['XRAY_JSON', 'XRAY_BASE64', 'MIHOMO', 'STASH', 'CLASH', 'SINGBOX'] as const;
+const ALPN_VALUES = ['h3', 'h2', 'http/1.1', 'h2,http/1.1', 'h3,h2,http/1.1', 'h3,h2'] as const;
+const MIHOMO_IP_VERSION = ['dual', 'ipv4', 'ipv6', 'ipv4-prefer', 'ipv6-prefer'] as const;
+const TAGS_DESC =
+    'Array of tags (uppercase letters, numbers, underscores and colons only; max 36 chars each, up to 10 tags)';
 
 export function registerHostTools(server: McpServer, client: RemnawaveClient, readonly: boolean) {
     server.tool(
@@ -65,27 +69,17 @@ export function registerHostTools(server: McpServer, client: RemnawaveClient, re
             configProfileInboundUuid: z
                 .string()
                 .describe('Config profile inbound UUID'),
-            path: z.string().optional().describe('URL path'),
-            sni: z.string().optional().describe('SNI (Server Name Indication)'),
-            host: z.string().optional().describe('Host header'),
+            path: z.string().nullish().describe('URL path'),
+            sni: z.string().nullish().describe('SNI (Server Name Indication)'),
+            host: z.string().nullish().describe('Host header'),
             alpn: z
-                .enum(['h3', 'h2', 'http/1.1', 'h2,http/1.1', 'h3,h2,http/1.1', 'h3,h2'])
+                .enum(ALPN_VALUES)
                 .optional()
                 .describe('ALPN protocol'),
             fingerprint: z
-                .enum([
-                    'chrome',
-                    'firefox',
-                    'safari',
-                    'ios',
-                    'android',
-                    'edge',
-                    'qq',
-                    'random',
-                    'randomized',
-                ])
+                .string()
                 .optional()
-                .describe('TLS fingerprint'),
+                .describe('TLS fingerprint (free-form, e.g. chrome, firefox, safari)'),
             isDisabled: z
                 .boolean()
                 .optional()
@@ -94,7 +88,22 @@ export function registerHostTools(server: McpServer, client: RemnawaveClient, re
                 .enum(['DEFAULT', 'TLS', 'NONE'])
                 .optional()
                 .describe('Security layer'),
-            tag: z.string().optional().describe('Host tag'),
+            tags: z
+                .array(z.string())
+                .optional()
+                .describe(TAGS_DESC),
+            pinnedPeerCertSha256: z
+                .string()
+                .nullish()
+                .describe('Pin peer certificate by SHA-256 fingerprint'),
+            verifyPeerCertByName: z
+                .string()
+                .nullish()
+                .describe('Verify peer certificate by name'),
+            mihomoIpVersion: z
+                .enum(MIHOMO_IP_VERSION)
+                .nullish()
+                .describe('IP version used by Mihomo clients'),
             serverDescription: z
                 .string()
                 .optional()
@@ -130,7 +139,13 @@ export function registerHostTools(server: McpServer, client: RemnawaveClient, re
                     body.isDisabled = params.isDisabled;
                 if (params.securityLayer !== undefined)
                     body.securityLayer = params.securityLayer;
-                if (params.tag !== undefined) body.tag = params.tag;
+                if (params.tags !== undefined) body.tags = params.tags;
+                if (params.pinnedPeerCertSha256 !== undefined)
+                    body.pinnedPeerCertSha256 = params.pinnedPeerCertSha256;
+                if (params.verifyPeerCertByName !== undefined)
+                    body.verifyPeerCertByName = params.verifyPeerCertByName;
+                if (params.mihomoIpVersion !== undefined)
+                    body.mihomoIpVersion = params.mihomoIpVersion;
                 if (params.serverDescription !== undefined)
                     body.serverDescription = params.serverDescription;
                 if (params.nodes !== undefined) body.nodes = params.nodes;
@@ -153,27 +168,17 @@ export function registerHostTools(server: McpServer, client: RemnawaveClient, re
             remark: z.string().optional().describe('New remark/name'),
             address: z.string().optional().describe('New address'),
             port: z.number().optional().describe('New port'),
-            path: z.string().optional().describe('New URL path'),
-            sni: z.string().optional().describe('New SNI'),
-            host: z.string().optional().describe('New host header'),
+            path: z.string().nullish().describe('New URL path'),
+            sni: z.string().nullish().describe('New SNI'),
+            host: z.string().nullish().describe('New host header'),
             alpn: z
-                .enum(['h3', 'h2', 'http/1.1', 'h2,http/1.1', 'h3,h2,http/1.1', 'h3,h2'])
+                .enum(ALPN_VALUES)
                 .optional()
                 .describe('New ALPN'),
             fingerprint: z
-                .enum([
-                    'chrome',
-                    'firefox',
-                    'safari',
-                    'ios',
-                    'android',
-                    'edge',
-                    'qq',
-                    'random',
-                    'randomized',
-                ])
+                .string()
                 .optional()
-                .describe('New fingerprint'),
+                .describe('New TLS fingerprint (free-form)'),
             isDisabled: z
                 .boolean()
                 .optional()
@@ -182,7 +187,22 @@ export function registerHostTools(server: McpServer, client: RemnawaveClient, re
                 .enum(['DEFAULT', 'TLS', 'NONE'])
                 .optional()
                 .describe('New security layer'),
-            tag: z.string().optional().describe('New tag'),
+            tags: z
+                .array(z.string())
+                .optional()
+                .describe(TAGS_DESC),
+            pinnedPeerCertSha256: z
+                .string()
+                .nullish()
+                .describe('Pin peer certificate by SHA-256 fingerprint'),
+            verifyPeerCertByName: z
+                .string()
+                .nullish()
+                .describe('Verify peer certificate by name'),
+            mihomoIpVersion: z
+                .enum(MIHOMO_IP_VERSION)
+                .nullish()
+                .describe('IP version used by Mihomo clients'),
             serverDescription: z
                 .string()
                 .optional()
@@ -249,27 +269,52 @@ export function registerHostTools(server: McpServer, client: RemnawaveClient, re
     );
 
     server.tool(
-        'hosts_bulk_set_inbound',
-        'Bulk set inbound for selected hosts',
+        'hosts_bulk_update',
+        'Bulk update fields on selected hosts (replaces the removed set-inbound / set-port endpoints)',
         {
-            uuids: z.array(z.string()).describe('Array of host UUIDs'),
-            configProfileUuid: z.string().describe('Config profile UUID'),
-            configProfileInboundUuid: z.string().describe('Inbound UUID'),
+            uuids: z.array(z.string()).describe('Array of host UUIDs to update'),
+            port: z.number().optional().describe('New port for all selected hosts'),
+            configProfileUuid: z
+                .string()
+                .optional()
+                .describe('Config profile UUID (set together with configProfileInboundUuid to change inbound)'),
+            configProfileInboundUuid: z
+                .string()
+                .optional()
+                .describe('Inbound UUID (set together with configProfileUuid to change inbound)'),
+            sni: z.string().nullish().describe('New SNI'),
+            host: z.string().nullish().describe('New host header'),
+            path: z.string().nullish().describe('New URL path'),
+            alpn: z.enum(ALPN_VALUES).optional().describe('New ALPN'),
+            fingerprint: z.string().optional().describe('New TLS fingerprint (free-form)'),
+            securityLayer: z.enum(['DEFAULT', 'TLS', 'NONE']).optional().describe('New security layer'),
+            isDisabled: z.boolean().optional().describe('Enable/disable selected hosts'),
+            tags: z.array(z.string()).optional().describe(TAGS_DESC),
+            mihomoIpVersion: z.enum(MIHOMO_IP_VERSION).nullish().describe('IP version used by Mihomo clients'),
+            excludeFromSubscriptionTypes: z
+                .array(z.enum(SUBSCRIPTION_TYPES))
+                .optional()
+                .describe('Subscription types to exclude these hosts from'),
         },
         async (params) => {
-            try { return toolResult(await client.bulkSetHostInbound(params)); } catch (e) { return toolError(e); }
-        },
-    );
-
-    server.tool(
-        'hosts_bulk_set_port',
-        'Bulk set port for selected hosts',
-        {
-            uuids: z.array(z.string()).describe('Array of host UUIDs'),
-            port: z.number().describe('New port number'),
-        },
-        async (params) => {
-            try { return toolResult(await client.bulkSetHostPort(params)); } catch (e) { return toolError(e); }
+            try {
+                const {
+                    configProfileUuid,
+                    configProfileInboundUuid,
+                    ...rest
+                } = params;
+                const body: Record<string, unknown> = { ...rest };
+                if (
+                    configProfileUuid !== undefined &&
+                    configProfileInboundUuid !== undefined
+                ) {
+                    body.inbound = {
+                        configProfileUuid,
+                        configProfileInboundUuid,
+                    };
+                }
+                return toolResult(await client.bulkUpdateHosts(body));
+            } catch (e) { return toolError(e); }
         },
     );
 

--- a/src/tools/inbounds.ts
+++ b/src/tools/inbounds.ts
@@ -108,6 +108,7 @@ export function registerInboundTools(
         {
             uuid: z.string().describe('Profile UUID'),
             name: z.string().optional().describe('New name'),
+            config: z.record(z.unknown()).optional().describe('Full Xray config object'),
         },
         async (params) => {
             try {
@@ -137,13 +138,20 @@ export function registerInboundTools(
 
     server.tool(
         'config_profiles_reorder',
-        'Reorder config profiles',
+        'Reorder config profiles by providing each profile UUID with its new position',
         {
-            uuids: z.array(z.string()).describe('Ordered array of profile UUIDs'),
+            items: z
+                .array(
+                    z.object({
+                        uuid: z.string().describe('Config profile UUID'),
+                        viewPosition: z.number().int().describe('New position (0-based)'),
+                    }),
+                )
+                .describe('Array of config profiles with their new positions'),
         },
-        async (params) => {
+        async ({ items }) => {
             try {
-                const result = await client.reorderConfigProfiles(params);
+                const result = await client.reorderConfigProfiles({ items });
                 return toolResult(result);
             } catch (e) {
                 return toolError(e);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,8 @@ import { registerSubPageConfigTools } from './subscription-page-configs.js';
 import { registerNodePluginTools } from './node-plugins.js';
 import { registerIpControlTools } from './ip-control.js';
 import { registerMetadataTools } from './metadata.js';
+import { registerSubscriptionSettingsTools } from './subscription-settings.js';
+import { registerSubscriptionTemplateTools } from './subscription-templates.js';
 
 export function registerAllTools(server: McpServer, client: RemnawaveClient, readonly: boolean) {
     registerUserTools(server, client, readonly);
@@ -38,4 +40,6 @@ export function registerAllTools(server: McpServer, client: RemnawaveClient, rea
     registerNodePluginTools(server, client, readonly);
     registerIpControlTools(server, client, readonly);
     registerMetadataTools(server, client, readonly);
+    registerSubscriptionSettingsTools(server, client, readonly);
+    registerSubscriptionTemplateTools(server, client, readonly);
 }

--- a/src/tools/nodes.ts
+++ b/src/tools/nodes.ts
@@ -261,15 +261,20 @@ export function registerNodeTools(server: McpServer, client: RemnawaveClient, re
 
     server.tool(
         'nodes_reorder',
-        'Reorder nodes by providing an ordered array of UUIDs',
+        'Reorder nodes by providing each node UUID with its new position',
         {
-            uuids: z
-                .array(z.string())
-                .describe('Ordered array of node UUIDs'),
+            nodes: z
+                .array(
+                    z.object({
+                        uuid: z.string().describe('Node UUID'),
+                        viewPosition: z.number().int().describe('New position (0-based)'),
+                    }),
+                )
+                .describe('Array of nodes with their new positions'),
         },
-        async ({ uuids }) => {
+        async ({ nodes }) => {
             try {
-                const result = await client.reorderNodes(uuids);
+                const result = await client.reorderNodes(nodes);
                 return toolResult(result);
             } catch (e) {
                 return toolError(e);

--- a/src/tools/nodes.ts
+++ b/src/tools/nodes.ts
@@ -81,6 +81,18 @@ export function registerNodeTools(server: McpServer, client: RemnawaveClient, re
                 .number()
                 .optional()
                 .describe('Traffic consumption multiplier'),
+            nodeConsumptionMultiplier: z
+                .number()
+                .optional()
+                .describe('Per-node traffic consumption multiplier (0.0–100.0)'),
+            note: z
+                .string()
+                .optional()
+                .describe('Free-form note (max 255 chars)'),
+            proxyUrl: z
+                .string()
+                .optional()
+                .describe('SOCKS5 proxy URL: socks5://[user:pass@]host:port'),
             activeConfigProfileUuid: z
                 .string()
                 .describe('Config profile UUID to assign'),
@@ -113,6 +125,10 @@ export function registerNodeTools(server: McpServer, client: RemnawaveClient, re
                     body.notifyPercent = params.notifyPercent;
                 if (params.consumptionMultiplier !== undefined)
                     body.consumptionMultiplier = params.consumptionMultiplier;
+                if (params.nodeConsumptionMultiplier !== undefined)
+                    body.nodeConsumptionMultiplier = params.nodeConsumptionMultiplier;
+                if (params.note !== undefined) body.note = params.note;
+                if (params.proxyUrl !== undefined) body.proxyUrl = params.proxyUrl;
 
                 const result = await client.createNode(body);
                 return toolResult(result);
@@ -151,6 +167,20 @@ export function registerNodeTools(server: McpServer, client: RemnawaveClient, re
                 .number()
                 .optional()
                 .describe('New consumption multiplier'),
+            nodeConsumptionMultiplier: z
+                .number()
+                .optional()
+                .describe('New per-node consumption multiplier (0.0–100.0)'),
+            note: z
+                .string()
+                .nullable()
+                .optional()
+                .describe('Free-form note (max 255 chars, null to clear)'),
+            proxyUrl: z
+                .string()
+                .nullable()
+                .optional()
+                .describe('SOCKS5 proxy URL: socks5://[user:pass@]host:port (null to clear)'),
         },
         async (params) => {
             try {
@@ -218,10 +248,14 @@ export function registerNodeTools(server: McpServer, client: RemnawaveClient, re
         'Restart a specific node',
         {
             uuid: z.string().describe('Node UUID'),
+            forceRestart: z
+                .boolean()
+                .default(false)
+                .describe('Force restart even if the node is unreachable'),
         },
-        async ({ uuid }) => {
+        async ({ uuid, forceRestart }) => {
             try {
-                const result = await client.restartNode(uuid);
+                const result = await client.restartNode(uuid, forceRestart);
                 return toolResult(result);
             } catch (e) {
                 return toolError(e);
@@ -232,10 +266,15 @@ export function registerNodeTools(server: McpServer, client: RemnawaveClient, re
     server.tool(
         'nodes_restart_all',
         'Restart all nodes',
-        {},
-        async () => {
+        {
+            forceRestart: z
+                .boolean()
+                .default(false)
+                .describe('Force restart even for unreachable nodes'),
+        },
+        async ({ forceRestart }) => {
             try {
-                const result = await client.restartAllNodes();
+                const result = await client.restartAllNodes(forceRestart);
                 return toolResult(result);
             } catch (e) {
                 return toolError(e);
@@ -320,13 +359,24 @@ export function registerNodeTools(server: McpServer, client: RemnawaveClient, re
         'nodes_bulk_update',
         'Bulk update properties for selected nodes',
         {
-            nodeUuids: z.array(z.string()).describe('Array of node UUIDs'),
+            uuids: z.array(z.string()).describe('Array of node UUIDs to update'),
             countryCode: z.string().optional().describe('New country code'),
-            consumptionMultiplier: z.number().optional().describe('New consumption multiplier'),
+            consumptionMultiplier: z.number().optional().describe('New consumption multiplier (0.0–100.0)'),
+            nodeConsumptionMultiplier: z.number().optional().describe('New per-node consumption multiplier (0.0–100.0)'),
+            note: z.string().nullable().optional().describe('Free-form note (max 255 chars, null to clear)'),
+            tags: z
+                .array(z.string())
+                .optional()
+                .describe('Tags (uppercase letters, numbers, underscores, colons; max 36 chars each, up to 10)'),
         },
         async (params) => {
             try {
-                const result = await client.bulkUpdateNodes(params);
+                const { uuids, ...fields } = params;
+                const cleanFields: Record<string, unknown> = {};
+                for (const [k, v] of Object.entries(fields)) {
+                    if (v !== undefined) cleanFields[k] = v;
+                }
+                const result = await client.bulkUpdateNodes({ uuids, fields: cleanFields });
                 return toolResult(result);
             } catch (e) {
                 return toolError(e);

--- a/src/tools/snippets.ts
+++ b/src/tools/snippets.ts
@@ -11,22 +11,22 @@ export function registerSnippetTools(server: McpServer, client: RemnawaveClient,
     if (readonly) return;
 
     server.tool('snippets_create', 'Create a new configuration snippet', {
-        name: z.string().describe('Snippet name'),
-        content: z.string().describe('Snippet content'),
+        name: z.string().describe('Snippet name (alphanumeric, spaces, underscores, hyphens; 2–255 chars)'),
+        snippet: z.array(z.record(z.unknown())).describe('Snippet content — array of Outbound or Rule objects'),
     }, async (params) => {
         try { return toolResult(await client.createSnippet(params)); } catch (e) { return toolError(e); }
     });
 
-    server.tool('snippets_update', 'Update an existing snippet', {
-        uuid: z.string().describe('Snippet UUID'),
-        name: z.string().optional().describe('New name'),
-        content: z.string().optional().describe('New content'),
+    server.tool('snippets_update', 'Update an existing snippet (identified by name)', {
+        name: z.string().describe('Current snippet name (used to identify the snippet)'),
+        newName: z.string().optional().describe('New name to rename the snippet to'),
+        snippet: z.array(z.record(z.unknown())).optional().describe('New content — array of Outbound or Rule objects'),
     }, async (params) => {
         try { return toolResult(await client.updateSnippet(params)); } catch (e) { return toolError(e); }
     });
 
-    server.tool('snippets_delete', 'Delete a snippet', {
-        uuid: z.string().describe('Snippet UUID to delete'),
+    server.tool('snippets_delete', 'Delete a snippet by name', {
+        name: z.string().describe('Snippet name to delete'),
     }, async (params) => {
         try { return toolResult(await client.deleteSnippet(params)); } catch (e) { return toolError(e); }
     });

--- a/src/tools/squads.ts
+++ b/src/tools/squads.ts
@@ -23,6 +23,22 @@ export function registerSquadTools(
     );
 
     server.tool(
+        'squads_get',
+        'Get a specific internal squad by UUID',
+        {
+            uuid: z.string().describe('Squad UUID'),
+        },
+        async ({ uuid }) => {
+            try {
+                const result = await client.getInternalSquadByUuid(uuid);
+                return toolResult(result);
+            } catch (e) {
+                return toolError(e);
+            }
+        },
+    );
+
+    server.tool(
         'squads_accessible_nodes',
         'Get nodes accessible to a specific squad',
         {
@@ -129,6 +145,29 @@ export function registerSquadTools(
                     squadUuid,
                     userUuids,
                 );
+                return toolResult(result);
+            } catch (e) {
+                return toolError(e);
+            }
+        },
+    );
+
+    server.tool(
+        'squads_reorder',
+        'Reorder internal squads by providing each squad UUID with its new position',
+        {
+            items: z
+                .array(
+                    z.object({
+                        uuid: z.string().describe('Squad UUID'),
+                        viewPosition: z.number().int().describe('New position (0-based)'),
+                    }),
+                )
+                .describe('Array of squads with their new positions'),
+        },
+        async ({ items }) => {
+            try {
+                const result = await client.reorderInternalSquads({ items });
                 return toolResult(result);
             } catch (e) {
                 return toolError(e);

--- a/src/tools/subscription-settings.ts
+++ b/src/tools/subscription-settings.ts
@@ -1,0 +1,41 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { RemnawaveClient } from '../client/index.js';
+import { toolResult, toolError } from './helpers.js';
+
+export function registerSubscriptionSettingsTools(server: McpServer, client: RemnawaveClient, readonly: boolean) {
+    server.tool(
+        'subscription_settings_get',
+        'Get Remnawave subscription settings',
+        {},
+        async () => {
+            try { return toolResult(await client.getSubscriptionSettings()); } catch (e) { return toolError(e); }
+        },
+    );
+
+    if (readonly) return;
+
+    server.tool(
+        'subscription_settings_update',
+        'Update Remnawave subscription settings',
+        {
+            uuid: z.string().describe('Settings UUID (required by API)'),
+            profileTitle: z.string().optional().describe('Profile title shown to clients'),
+            supportLink: z.string().optional().describe('Support link URL'),
+            profileUpdateInterval: z.number().int().optional().describe('Profile update interval in seconds'),
+            isProfileWebpageUrlEnabled: z.boolean().optional().describe('Enable profile webpage URL'),
+            serveJsonAtBaseSubscription: z.boolean().optional().describe('Serve JSON at base subscription URL'),
+            happAnnounce: z.string().nullable().optional().describe('HAPP announce URL'),
+            happRouting: z.string().nullable().optional().describe('HAPP routing configuration'),
+            isShowCustomRemarks: z.boolean().optional().describe('Show custom remarks'),
+            customRemarks: z.record(z.unknown()).optional().describe('Custom remarks object'),
+            customResponseHeaders: z.record(z.unknown()).optional().describe('Custom response headers'),
+            randomizeHosts: z.boolean().optional().describe('Randomize host order in subscriptions'),
+            responseRules: z.record(z.unknown()).optional().describe('Response rules configuration'),
+            hwidSettings: z.record(z.unknown()).optional().describe('HWID settings configuration'),
+        },
+        async (params) => {
+            try { return toolResult(await client.updateSubscriptionSettings(params)); } catch (e) { return toolError(e); }
+        },
+    );
+}

--- a/src/tools/subscription-templates.ts
+++ b/src/tools/subscription-templates.ts
@@ -1,0 +1,88 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { RemnawaveClient } from '../client/index.js';
+import { toolResult, toolError } from './helpers.js';
+
+const TEMPLATE_TYPES = ['XRAY_JSON', 'XRAY_BASE64', 'MIHOMO', 'STASH', 'CLASH', 'SINGBOX'] as const;
+
+export function registerSubscriptionTemplateTools(server: McpServer, client: RemnawaveClient, readonly: boolean) {
+    server.tool(
+        'subscription_templates_list',
+        'List all subscription templates',
+        {},
+        async () => {
+            try { return toolResult(await client.getSubscriptionTemplates()); } catch (e) { return toolError(e); }
+        },
+    );
+
+    server.tool(
+        'subscription_templates_get',
+        'Get a subscription template by UUID',
+        {
+            uuid: z.string().describe('Template UUID'),
+        },
+        async ({ uuid }) => {
+            try { return toolResult(await client.getSubscriptionTemplateByUuid(uuid)); } catch (e) { return toolError(e); }
+        },
+    );
+
+    if (readonly) return;
+
+    server.tool(
+        'subscription_templates_create',
+        'Create a new subscription template',
+        {
+            name: z.string().describe('Template name'),
+            templateType: z.enum(TEMPLATE_TYPES).describe('Template type (client format)'),
+        },
+        async (params) => {
+            try { return toolResult(await client.createSubscriptionTemplate(params)); } catch (e) { return toolError(e); }
+        },
+    );
+
+    server.tool(
+        'subscription_templates_update',
+        'Update an existing subscription template',
+        {
+            uuid: z.string().describe('Template UUID'),
+            name: z.string().optional().describe('New template name'),
+            templateJson: z.record(z.unknown()).optional().describe('Template JSON configuration object'),
+            encodedTemplateYaml: z.string().optional().describe('Base64-encoded YAML template'),
+        },
+        async (params) => {
+            try { return toolResult(await client.updateSubscriptionTemplate(params)); } catch (e) { return toolError(e); }
+        },
+    );
+
+    server.tool(
+        'subscription_templates_delete',
+        'Delete a subscription template',
+        {
+            uuid: z.string().describe('Template UUID to delete'),
+        },
+        async ({ uuid }) => {
+            try {
+                await client.deleteSubscriptionTemplate(uuid);
+                return toolResult({ success: true, message: `Template ${uuid} deleted` });
+            } catch (e) { return toolError(e); }
+        },
+    );
+
+    server.tool(
+        'subscription_templates_reorder',
+        'Reorder subscription templates by providing each template UUID with its new position',
+        {
+            items: z
+                .array(
+                    z.object({
+                        uuid: z.string().describe('Template UUID'),
+                        viewPosition: z.number().int().describe('New position (0-based)'),
+                    }),
+                )
+                .describe('Array of templates with their new positions'),
+        },
+        async ({ items }) => {
+            try { return toolResult(await client.reorderSubscriptionTemplates({ items })); } catch (e) { return toolError(e); }
+        },
+    );
+}

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -36,6 +36,37 @@ export function registerSystemTools(
     );
 
     server.tool(
+        'bandwidth_stats_users_by_nodes',
+        'Get top per-user bandwidth usage across the given nodes for a date range',
+        {
+            nodesUuids: z
+                .array(z.string())
+                .min(1)
+                .describe('Array of node UUIDs (at least one)'),
+            start: z.string().describe('Start date (YYYY-MM-DD)'),
+            end: z.string().describe('End date (YYYY-MM-DD)'),
+            topUsersLimit: z
+                .number()
+                .int()
+                .optional()
+                .describe('Max number of top users to return (default 100)'),
+        },
+        async ({ nodesUuids, start, end, topUsersLimit }) => {
+            try {
+                const result = await client.getUsersUsageByNodes(
+                    nodesUuids,
+                    start,
+                    end,
+                    topUsersLimit,
+                );
+                return toolResult(result);
+            } catch (e) {
+                return toolError(e);
+            }
+        },
+    );
+
+    server.tool(
         'system_nodes_metrics',
         'Get detailed node metrics',
         {},

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -134,6 +134,38 @@ export function registerUserTools(server: McpServer, client: RemnawaveClient, re
     );
 
     server.tool(
+        'users_get_by_id',
+        'Get a Remnawave user by their numeric ID',
+        {
+            id: z.string().describe('User numeric ID'),
+        },
+        async ({ id }) => {
+            try {
+                const result = await client.getUserById(id);
+                return toolResult(result);
+            } catch (e) {
+                return toolError(e);
+            }
+        },
+    );
+
+    server.tool(
+        'users_accessible_nodes',
+        'Get nodes accessible to a specific user',
+        {
+            uuid: z.string().describe('User UUID'),
+        },
+        async ({ uuid }) => {
+            try {
+                const result = await client.getUserAccessibleNodes(uuid);
+                return toolResult(result);
+            } catch (e) {
+                return toolError(e);
+            }
+        },
+    );
+
+    server.tool(
         'users_tags_list',
         'List all user tags',
         {},


### PR DESCRIPTION
## What changed

Four commits that align the MCP server with the current Remnawave API (validated against a live panel running backend 2.8.0) and fill in missing endpoint coverage. Version bumped to 1.4.0.

### Bug fixes (requests previously failed against the API)
- **Snippets**: field `content` → `snippet` per `CreateSnippetRequestDto`/`UpdateSnippetRequestDto`; delete/update now identify snippets by `name` (the API has no snippet uuid); `deleteSnippet` uses `DELETE` with a body instead of `POST`.
- **`nodes_reorder` / `config_profiles_reorder`**: were sending `string[]` / `{uuids}`, but the API expects `{nodes: [{uuid, viewPosition}]}` / `{items: [{uuid, viewPosition}]}` — these calls could never succeed.
- **`nodes_bulk_update`**: was sending a flat body; the API expects `{uuids, fields: {...}}`.

### New tools
`hosts_reorder`, `squads_get`, `squads_reorder`, `users_get_by_id`, `users_accessible_nodes`, `subscription_settings_get/update`, `subscription_templates_list/get/create/update/delete/reorder`, `bandwidth_stats_users_by_nodes` — total tool count 166.

### Panel 2.8.0 support
- `hosts_bulk_update` replaces the removed `set-inbound`/`set-port` endpoints (they return 404 on 2.8.0).
- Hosts: single `tag` → `tags` array, `fingerprint` enum → free-form string, added `pinnedPeerCertSha256`/`verifyPeerCertByName` (replacing `allowInsecure`), `mihomoIpVersion`; `host`/`path`/`sni` nullable.
- Nodes: added `nodeConsumptionMultiplier`, `note`, `proxyUrl`; restart endpoints now send the required `forceRestart` body.

### Why the dependency is pinned
`@remnawave/backend-contract` is pinned to exactly `2.7.2`: the npm package versioning has diverged from panel versioning — 2.9.x renames `IP_CONTROL`→`CONNECTIONS` and drops several `USERS.GET_BY` routes that a 2.8.0 panel still serves. Routes newer than the pinned contract are declared as literal strings with comments.

## How it was verified
- `tsc --noEmit` and `tsup` build clean; stdio smoke test (`initialize` → `tools/list`) registers all 166 tools.
- Against a live 2.8.0 panel: the new bandwidth endpoint returns 200 with the documented shape; removed host bulk endpoints return 404; new body shapes for hosts/nodes bulk-update pass validation (400 only on intentionally empty `uuids`, so nothing was mutated).

## Reviewer notes
- README (EN+RU) updated: tool tables, readonly counts (76), project structure.
- `hosts_bulk_set_inbound`/`hosts_bulk_set_port` are removed rather than deprecated, matching the API's own removal without deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)